### PR TITLE
Feat/#42 소셜 로그인 로직 수정

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -57,22 +57,5 @@ jobs:
             docker stop server || true
             docker container prune -f
             docker run -d --name server -p 8080:8080 --network redis-network \
-            -e PROFILE=dev \
-            -e DB_PATH=${{secrets.DB_PATH}} \
-            -e DB_USER=${{secrets.DB_USER}} \
-            -e DB_PASSWORD=${{secrets.DB_PASSWORD}} \
-            -e JUSO_API_KEY=${{secrets.JUSO_API_KEY}} \
-            -e JWT_SECRET=${{secrets.JWT_SECRET}} \
-            -e KAKAO_CLIENT_ID=${{secrets.KAKAO_CLIENT_ID}} \
-            -e KAKAO_CLIENT_SECRET=${{secrets.KAKAO_CLIENT_SECRET}} \
-            -e NAVER_CLIENT_ID=${{secrets.NAVER_CLIENT_ID}} \
-            -e NAVER_CLIENT_SECRET=${{secrets.NAVER_CLIENT_SECRET}} \
-            -e NAVER_STATE=${{secrets.NAVER_STATE}} \
-            -e S3_ACCESS_KEY=${{secrets.S3_ACCESS_KEY}} \
-            -e S3_BUCKET=${{secrets.S3_BUCKET}} \
-            -e S3_SECRET_KEY=${{secrets.S3_SECRET_KEY}} \
-            -e SERVER_URL=${{secrets.SERVER_URL}} \
-            -e TMAP_APP_KEY=${{secrets.TMAP_APP_KEY}} \
-            -e WEBHOOK_SLACK_URL=${{secrets.WEBHOOK_SLACK_URL}} \
-            -e ALLOWED_ORIGINS=${{secrets.ALLOWED_ORIGINS}} \
+            --env-file ./.env \
             yun8565/mobby-server-dev:latest

--- a/src/main/java/com/safer/safer/auth/dto/LoginUriResponse.java
+++ b/src/main/java/com/safer/safer/auth/dto/LoginUriResponse.java
@@ -1,0 +1,9 @@
+package com.safer.safer.auth.dto;
+
+public record LoginUriResponse(
+        String loginUri
+) {
+    public static LoginUriResponse of(String loginUri) {
+        return new LoginUriResponse(loginUri);
+    }
+}

--- a/src/main/java/com/safer/safer/auth/presentation/AuthController.java
+++ b/src/main/java/com/safer/safer/auth/presentation/AuthController.java
@@ -1,14 +1,12 @@
 package com.safer.safer.auth.presentation;
 
 import com.safer.safer.auth.dto.AccessTokenResponse;
+import com.safer.safer.auth.dto.LoginUriResponse;
 import com.safer.safer.auth.dto.UserTokens;
 import com.safer.safer.auth.application.AuthService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
-import java.net.URI;
 
 @RestController
 @RequiredArgsConstructor
@@ -18,11 +16,9 @@ public class AuthController {
     private final AuthService authService;
 
     @GetMapping("/{provider}")
-    public ResponseEntity<Void> findLoginRedirectUri(@PathVariable final String provider) {
+    public ResponseEntity<LoginUriResponse> findLoginRedirectUri(@PathVariable final String provider) {
         String loginRedirectUri = authService.generateLoginRedirectUri(provider);
-        return ResponseEntity.status(HttpStatus.FOUND)
-                .location(URI.create(loginRedirectUri))
-                .build();
+        return ResponseEntity.ok(LoginUriResponse.of(loginRedirectUri));
     }
 
     @GetMapping("/login/{provider}")

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -26,7 +26,7 @@ oauth2:
     response-type: code
     grant-type: authorization_code
     authorization-uri: https://kauth.kakao.com/oauth/authorize
-    redirect-uri: ${SERVER_URL}/api/oauth/login/kakao
+    redirect-uri: ${CLIENT_URL}/oauth/kakao
     token-uri: https://kauth.kakao.com/oauth/token
     user-info-uri: https://kapi.kakao.com/v2/user/me
 
@@ -37,7 +37,7 @@ oauth2:
     grant-type: authorization_code
     state: ${NAVER_STATE}
     authorization-uri: https://nid.naver.com/oauth2.0/authorize
-    redirect-uri: ${SERVER_URL}/api/oauth/login/naver
+    redirect-uri: ${CLIENT_URL}/oauth/naver
     token-uri: https://nid.naver.com/oauth2.0/token
     user-info-uri: https://openapi.naver.com/v1/nid/me
 

--- a/src/test/java/com/safer/safer/auth/presentation/AuthControllerTest.java
+++ b/src/test/java/com/safer/safer/auth/presentation/AuthControllerTest.java
@@ -44,7 +44,7 @@ public class AuthControllerTest extends ControllerTest {
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .accept(MediaType.APPLICATION_JSON)
                 )
-                .andExpect(MockMvcResultMatchers.status().isFound())
+                .andExpect(MockMvcResultMatchers.status().isOk())
                 .andDo(
                         MockMvcRestDocumentationWrapper.document(
                                 "{class-name}/{method-name}",
@@ -53,13 +53,13 @@ public class AuthControllerTest extends ControllerTest {
                                 resource(
                                         ResourceSnippetParameters.builder()
                                                 .tag("로그인 API")
-                                                .summary("소셜 로그인 창 불러오기")
-                                                .description("로그인 화면으로 리다이렉트")
+                                                .summary("소셜 로그인 URI 요청")
+                                                .description("로그인 URI를 통해 인증 코드 발급")
                                                 .pathParameters(
                                                         parameterWithName("provider").description("소셜 로그인 종류 [kakao, naver]")
                                                 )
-                                                .responseHeaders(
-                                                        headerWithName("Location").description("리다이렉트 링크")
+                                                .responseFields(
+                                                        fieldWithPath("loginUri").description("로그인 URI")
                                                 )
                                                 .build()
                                 )
@@ -90,7 +90,7 @@ public class AuthControllerTest extends ControllerTest {
                                         ResourceSnippetParameters.builder()
                                                 .tag("로그인 API")
                                                 .summary("토큰 발급")
-                                                .description("로그인 이후 AccessToken 발급 (로그인에 성공하면 자동으로 호출됩니다.\n실제로는 로그인 화면을 요청하면 AccessToken을 바로 받을 수 있습니다.)")
+                                                .description("AccessToken을 발급 받습니다.")
                                                 .pathParameters(
                                                         parameterWithName("provider").description("소셜 로그인 종류 [kakao, naver]")
                                                 )


### PR DESCRIPTION
문제가 있었던 기존 방식
- redirect uri를 서버로 설정해놔서  로그인 성공 시 정상적으로 인증 토큰이 클라이언트에 전달되지 않는다.

해결 방법
- 소셜 로그인 요청이 들어오면 서버는 로그인 URL만 생성해서 클라이언트로 전달한다.
- 클라이언트는 로그인 URL를 통해 로그인, 성공 시 인증 코드를 발급 받는다.
- 인증 코드를 포함한 요청을 서버로 보내면 토큰을 정상적으로 전달 받을 수 있다.

- 카카오, 네이버 로그인 설정 페이지에서 콜백URL 수정

closes #42 